### PR TITLE
Fixed "minecraft" folder not found bug.

### DIFF
--- a/src/main/java/com/skcraft/launcher/Instance.java
+++ b/src/main/java/com/skcraft/launcher/Instance.java
@@ -68,7 +68,11 @@ public class Instance implements Comparable<Instance> {
      */
     @JsonIgnore
     public File getContentDir() {
-        return new File(dir, "minecraft");
+        File dir = new File(this.dir, "minecraft");
+        if (!dir.exists()) {
+            dir.mkdirs();
+        }
+        return dir;
     }
 
     /**


### PR DESCRIPTION
Sorry I made a new one, but git wasn't cooperating at first. Hope this is fine now.
