### PR TITLE
Updated maven_repos.json

### DIFF
--- a/launcher/src/main/resources/com/skcraft/launcher/maven_repos.json
+++ b/launcher/src/main/resources/com/skcraft/launcher/maven_repos.json
@@ -1,5 +1,5 @@
 [
   "https://libraries.minecraft.net/",
-  "https://central.maven.org/maven2/",
+  "https://repo1.maven.org/maven2/",
   "http://maven.apache.org/"
 ]


### PR DESCRIPTION
https://central.maven.org/ now forces users to use https://repo1.maven.org