### PR TITLE
Added redirect support for most HTTP 300 response codes

### DIFF
--- a/launcher/src/main/java/com/skcraft/launcher/util/HttpRequest.java
+++ b/launcher/src/main/java/com/skcraft/launcher/util/HttpRequest.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.skcraft.concurrency.ProgressObservable;
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.extern.java.Log;
 
 import javax.xml.bind.JAXBContext;
@@ -181,6 +182,16 @@ public class HttpRequest implements Closeable, ProgressObservable {
         }
 
         return conn.getResponseCode();
+    }
+
+    /**
+     * Get a specified header.
+     *
+     * @param Header to retrieve
+     * @return The header requested or null if it doesn't exist
+     */
+    public String getHeader(@NonNull String headerName) {
+	return conn.getHeaderField(headerName);
     }
 
     /**


### PR DESCRIPTION
I deliberately didn't include all 300 codes since some of them would require special handling (such as 'use proxy') outside of the scope of what I was trying to fix.  This should fix #93 
