### PR TITLE
MacOS custom dir support

### DIFF
--- a/launcher-bootstrap/src/main/java/com/skcraft/launcher/Bootstrap.java
+++ b/launcher-bootstrap/src/main/java/com/skcraft/launcher/Bootstrap.java
@@ -194,6 +194,8 @@ public class Bootstrap {
         String osName = System.getProperty("os.name").toLowerCase();
         if (osName.contains("win")) {
             return new File(getFileChooseDefaultDir(), getProperties().getProperty("homeFolderWindows"));
+        } else if (osName.contains("mac") && getProperties().getProperty("homeFolderMac") != null) {
+            return new File(getFileChooseDefaultDir(), getProperties().getProperty("homeFolderMac"));
         } else {
             return new File(System.getProperty("user.home"), getProperties().getProperty("homeFolder"));
         }

--- a/launcher-bootstrap/src/main/resources/com/skcraft/launcher/bootstrap.properties
+++ b/launcher-bootstrap/src/main/resources/com/skcraft/launcher/bootstrap.properties
@@ -5,6 +5,7 @@
 #
 
 homeFolderWindows=Example Launcher
+homeFolderMac=Library/Application Support/ExampleLauncher
 homeFolder=.examplelauncher
 launcherClass=com.skcraft.launcher.Launcher
 latestUrl=http://update.skcraft.com/quark/launcher/latest.json


### PR DESCRIPTION
Gives the opportunity to store launcher data in `Library/Application Support/<something>`