### PR TITLE
Fix runtime issue with Java 9 (java.xml.bind API)

### DIFF
--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -8,6 +8,7 @@ jar {
 
 dependencies {
     compile 'org.projectlombok:lombok:1.12.2'
+    compile 'javax.xml.bind:jaxb-api:2.2.4'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.3.0'
     compile 'commons-lang:commons-lang:2.6'
     compile 'commons-io:commons-io:1.2'


### PR DESCRIPTION
When run with java 9 I experienced an exception like `java.lang.NoClassDefFoundError: javax/xml/bind/JAXBException`. It occured when using the class `com.skcraft.launcher.util.HttpRequest`. [This stackoverflow question](https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j) mentions that the API in use is not included in the runtime by default, and one option is to add it as a separate dependency.
It seems that the API is only used in conjunction with jackson here, so adding it as a separate dependency should fix the issue.
Comments & feedback are welcome, especially if there are side effects I have overlooked.