### PR TITLE
Fix RecentEntry on Builder

### DIFF
--- a/creator-tools/src/main/java/com/skcraft/launcher/creator/model/creator/RecentEntry.java
+++ b/creator-tools/src/main/java/com/skcraft/launcher/creator/model/creator/RecentEntry.java
@@ -6,6 +6,7 @@
 
 package com.skcraft.launcher.creator.model.creator;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 
 import java.io.File;
@@ -20,6 +21,7 @@ public class RecentEntry {
     }
 
     @Override
+    @JsonProperty("path")
     public String toString() {
         return path.getAbsolutePath();
     }


### PR DESCRIPTION
Without this the full File Object will be written to the config.json results into this:

```
{"recentEntries":[{"path":{"path":"/Users/jan/Downloads/TEST-MOD","parent":"/Users/jan/Downloads","hidden":false,"displayName":"TEST-MOD","linkLocation":null,"executableType":null,"folderType":"File Folder","link":false,"absolute":true,"parentFile":"/Users/jan/Downloads","absoluteFile":"/Users/jan/Downloads/TEST-MOD","directory":true,"file":false,"folderColumns":null,"fileSystem":true,"name":"TEST-MOD","canonicalPath":"/Users/jan/Downloads/TEST-MOD","absolutePath":"/Users/jan/Downloads/TEST-MOD","canonicalFile":"/Users/jan/Downloads/TEST-MOD","totalSpace":499418034176,"freeSpace":300791361536,"usableSpace":296845651968}}],"offlineEnabled":false}
```

Also I'm getting an loading error:

```
[information] Failed to loadcom.skcraft.launcher.creator.model.creator.CreatorConfig
com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of java.io.File out of START_OBJECT token
 at [Source: java.io.BufferedInputStream@cb5822; line: 1, column: 20] (through reference chain: com.skcraft.launcher.creator.model.creator.CreatorConfig["recentEntries"]->com.skcraft.launcher.creator.model.creator.RecentEntry["path"])
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:164)
	at com.fasterxml.jackson.databind.DeserializationContext.mappingException(DeserializationContext.java:691)
	at com.fasterxml.jackson.databind.DeserializationContext.mappingException(DeserializationContext.java:685)
	at com.fasterxml.jackson.databind.deser.std.FromStringDeserializer.deserialize(FromStringDeserializer.java:61)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:525)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:99)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:242)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:118)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:227)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:204)
	at com.fasterxml.jackson.databind.deser.std.CollectionDeserializer.deserialize(CollectionDeserializer.java:23)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:525)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:99)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:242)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:118)
	at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:2986)
	at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2137)
	at com.skcraft.launcher.persistence.Persistence.read(Persistence.java:115)
	at com.skcraft.launcher.persistence.Persistence.load(Persistence.java:189)
	at com.skcraft.launcher.persistence.Persistence.load(Persistence.java:206)
	at com.skcraft.launcher.creator.Creator.<init>(Creator.java:36)
	at com.skcraft.launcher.creator.Creator.main(Creator.java:74)
```

This PR fixes the Recent Entries on the builder