### PR TITLE
Fix for issue 235

### DIFF
--- a/launcher/src/main/java/com/skcraft/launcher/model/minecraft/Argument.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/minecraft/Argument.java
@@ -1,0 +1,110 @@
+/*
+ * part of the new version manifest handling, see https://github.com/SKCraft/Launcher/issues/235
+ * based on the pull request https://github.com/SKCraft/Launcher/pull/265 from EazFTW
+ */
+package com.skcraft.launcher.model.minecraft;
+
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.skcraft.launcher.util.Environment;
+
+@JsonDeserialize(using = ArgumentDeserializer.class)
+@JsonSerialize(using = ArgumentSerializer.class)
+public class Argument {
+
+    // argument can be both a string, or a complex object with a list of rules and a list of arguments 
+
+    String[]  arguments;
+
+    ArgumentRule[] rules; 
+
+    public boolean applies(Environment env) {
+        // some of them must be skipped
+        // -Djava.library.path is already handled by com.skcraft.launcher.launch.Runner.addLibraries()
+        if (argumentContains("-Djava.library.path")) {
+            return false;
+        }
+        // width and height are already handled by com.skcraft.launcher.launch.Runner.addWindowArgs()
+        if (argumentContains("--width") || argumentContains("--height")) {
+            return false;
+        }
+        // -cp and ${classpath} are handled by com.skcraft.launcher.launch.JavaProcessBuilder
+        // those are two different arguments:
+        if (argumentIs("-cp") || argumentContains("${classpath}")) {
+            return false;
+        }
+        // for all other arguments, if rules are given, check if they apply:
+        if (rules != null) {
+            for (ArgumentRule r : rules) {
+                if (!r.applies(env))
+                    return false;
+            }
+        }
+        else if (env != null) { 
+            // env if only != null for the OS specific arguments
+            // i.e. those that have a rule with os != null
+            // if there are no rules, it can't be an OS specific argument  
+            return false; 
+        }
+        return true;
+    }
+
+    private boolean argumentIs(String argPart) {
+        for (String arg : arguments) {
+            if (arg.equalsIgnoreCase(argPart)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean argumentContains(String argPart) {
+        for (String arg : arguments) {
+            if (arg.contains(argPart)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public void setArgument(JsonNode node) {
+        if (node.isArray()) {
+            arguments = new String[node.size()];
+            for (int i = 0; i < node.size(); i++) {
+                arguments[i] = node.get(i).asText();
+            }
+        }
+        else { // _should_ be TextNode  
+            arguments = new String[1];
+            arguments[0] = node.asText();
+        }
+        
+    }
+
+    public void setRules(JsonNode rulesNode) throws JsonProcessingException {
+        if (rulesNode.isArray()) {
+            rules = new ArgumentRule[rulesNode.size()];
+            for (int i = 0; i < rulesNode.size(); i++) {
+                rules[i] = new ArgumentRule(rulesNode.get(i));
+            }
+        }
+        else {
+            throw new JsonGenerationException("Parsing Argument: rules is not an array.");
+        }
+    }
+
+    public void addArgs(ArrayList<String> args, Environment environment) {
+        if (applies(environment)) {
+            for (String arg : arguments) {
+                args.add(arg);
+            }
+        }
+        
+    }
+
+}

--- a/launcher/src/main/java/com/skcraft/launcher/model/minecraft/ArgumentDeserializer.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/minecraft/ArgumentDeserializer.java
@@ -1,0 +1,48 @@
+/*
+ * part of the new version manifest handling, see https://github.com/SKCraft/Launcher/issues/235
+ * based on the pull request https://github.com/SKCraft/Launcher/pull/265 from EazFTW
+ */
+package com.skcraft.launcher.model.minecraft;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.node.TextNode;
+
+public class ArgumentDeserializer extends StdDeserializer<Argument> {
+
+    /**
+     * serial version ID (eclipse gives a warning if it is not present)
+     */
+    private static final long serialVersionUID = 1L;
+
+    public ArgumentDeserializer() {
+        this(null);
+    }
+
+    public ArgumentDeserializer(Class<?> vc) { 
+        super(vc); 
+    }
+
+    @Override
+    public Argument deserialize(JsonParser jp, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+
+        Argument arg = new Argument();
+        JsonNode node = jp.getCodec().readTree(jp);
+
+        if (node instanceof TextNode) {
+            arg.setArgument(node);
+        }
+        else {
+            arg.setArgument(node.get("value"));
+            arg.setRules(node.get("rules"));
+        }
+        return arg;
+    }
+
+}

--- a/launcher/src/main/java/com/skcraft/launcher/model/minecraft/ArgumentRule.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/minecraft/ArgumentRule.java
@@ -1,0 +1,177 @@
+/*
+ * part of the new version manifest handling, see https://github.com/SKCraft/Launcher/issues/235
+ * based on the pull request https://github.com/SKCraft/Launcher/pull/265 from EazFTW
+ */
+package com.skcraft.launcher.model.minecraft;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import com.fasterxml.jackson.core.JsonGenerationException;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.skcraft.launcher.util.Environment;
+
+import lombok.extern.java.Log;
+
+@Log
+public class ArgumentRule {
+
+    private String action;
+    private Map<String, Boolean> features;
+    private Map<String, String> os;
+
+    public ArgumentRule(JsonNode node) throws JsonProcessingException {
+        action = node.get("action").asText();
+        if (node.has("features")) { 
+            features = new HashMap<String, Boolean>();
+            JsonNode featNode = node.get("features");
+            if (featNode.isObject()) {
+                for (Iterator<String> feats  = featNode.fieldNames(); feats.hasNext(); ) {
+                    String feat = feats.next();
+                    features.put(feat, featNode.get(feat).asBoolean());
+                }
+            }
+            else {
+                throw new JsonGenerationException("Parsing Argument: rules.features is not an object.");
+            }
+        }
+        if (node.has("os")) { 
+            os = new HashMap<String, String>();
+            JsonNode osNode = node.get("os");
+            if (osNode.isObject()) {
+                for (Iterator<String> osSpec  = osNode.fieldNames(); osSpec.hasNext(); ) {
+                    String spec = osSpec.next();
+                    os.put(spec, osNode.get(spec).asText());
+                }
+            }
+            else {
+                throw new JsonGenerationException("Parsing Argument: rules.features is not an object.");
+            }
+        }
+    }
+
+    public boolean applies(Environment env) {
+        boolean conditionsMet = appliesInternal(env);
+        // this assumes that any action except "allow" means "deny" 
+        // TODO: is this true? I have only seen "allow"
+        return action.equalsIgnoreCase("allow") ? conditionsMet : !conditionsMet;
+    }
+
+    private boolean appliesInternal(Environment env) {
+        // OS-dependent conditions:
+        if (env != null) {
+            // must be an OS-dependent rule:
+            if (os == null)
+                return false;
+            for (Map.Entry<String, String> entry : os.entrySet()) {
+                if (!envConditionMet(entry.getKey(), entry.getValue(), env))
+                    return false;
+            }
+        }
+        else {
+            // must not be an os-independent rule:
+            if (os != null)
+                return false;
+        }
+
+        // OS-independent conditions: as of now, I haven't seen that
+        // both are present, but to be safe, check both even if env is set
+        if (features != null) {
+            for (Map.Entry<String, Boolean> entry : features.entrySet()) {
+                if (!conditionMet(entry.getKey(), entry.getValue()))
+                    return false;
+            }
+        }
+        // all conditions met
+        return true;
+    }
+
+    private boolean conditionMet(String key, Boolean value) {
+        // the only ones seen so far are is_demo_user and has_custom_resolution
+        if (key.equalsIgnoreCase("is_demo_user")) {
+            // TODO: how to find out if it is a demo user? Is this even possible?
+            return false;
+        }
+        if (key.equalsIgnoreCase("has_custom_resolution")) {
+            // as of now only used to set --width and --height
+            // those are already handled in Runner.addWindowArgs()
+            // which uses values from the config, and I don't know what else to do here, so
+            // simply ignore it
+            return false;
+        }
+        // unknown key: TODO: implement it!
+        log.warning("[ArgumentRule] condition '" + key + "' not yet implemented!");
+        
+        return false;
+    }
+
+    private boolean envConditionMet(String key, String value, Environment env) {
+        if (key.equalsIgnoreCase("name")) {
+            // only "windows" and "osx" was seen in the wild ...
+            switch (env.getPlatform()) {
+            case WINDOWS:
+                return value.equalsIgnoreCase("windows");
+            case MAC_OS_X:
+                return value.equalsIgnoreCase("osx");
+            case LINUX:
+                // we can only assume
+                return value.toLowerCase().contains("linux");
+            case SOLARIS:
+                // we can only assume
+                return value.toLowerCase().contains("solaris");
+            case UNKNOWN:
+                // no way to match this
+                return false;
+            }
+        }
+        if (key.equalsIgnoreCase("version")) {
+            // value is a regex
+            return Pattern.matches(value, env.getPlatformVersion());
+        }
+        if (key.equalsIgnoreCase("arch")) { // introduced after 1.13.2
+            // only "x86"  was seen. the other is probably x64? 
+            if (value.equalsIgnoreCase("x86")) {
+                return env.getArchBits().equals("32");
+            }
+            // can we simply assume that x64 is the only other possible value?
+            // if it is a value at all ... 
+            if (value.contains("64")) { // this is a bit more generic
+                return env.getArchBits().equals("64");
+            }
+            // (as of now), environment returns either 32 or 64, so every other value 
+            // should either be added to one of the conditions above, or can't be matched:
+            log.warning("[ArgumentRule] OS condition '" + key + "': unknown architecture " + value);
+            return false;
+        }
+        // unknown key: TODO: implement it!
+        log.warning("[ArgumentRule] OS condition '" + key + "' not yet implemented!");
+
+        return false;
+    }
+
+    public void serialize(JsonGenerator jgen) throws JsonProcessingException, IOException {
+        jgen.writeStartObject();
+        jgen.writeStringField("action", action);
+        if (features != null) {
+            jgen.writeObjectFieldStart("features");
+            for (Map.Entry<String, Boolean> entry : features.entrySet()) {
+                jgen.writeBooleanField(entry.getKey(), entry.getValue());
+            }
+            jgen.writeEndObject();
+        }
+        if (os != null) {
+            jgen.writeObjectFieldStart("os");
+            for (Map.Entry<String, String> entry : os.entrySet()) {
+                jgen.writeStringField(entry.getKey(), entry.getValue());
+            }
+            jgen.writeEndObject();
+        }
+        jgen.writeEndObject();
+    }
+
+}

--- a/launcher/src/main/java/com/skcraft/launcher/model/minecraft/ArgumentSerializer.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/minecraft/ArgumentSerializer.java
@@ -1,0 +1,51 @@
+/*
+ * part of the new version manifest handling, see https://github.com/SKCraft/Launcher/issues/235
+ * based on the pull request https://github.com/SKCraft/Launcher/pull/265 from EazFTW
+ */
+package com.skcraft.launcher.model.minecraft;
+
+import java.io.IOException;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import com.fasterxml.jackson.databind.ser.std.StdSerializer;
+
+public class ArgumentSerializer extends StdSerializer<Argument> {
+
+    public ArgumentSerializer() {
+        this(null);
+    }
+
+    public ArgumentSerializer(Class<Argument> t) {
+        super(t);
+    }
+
+    @Override
+    public void serialize(Argument value, JsonGenerator jgen, SerializerProvider provider) 
+      throws IOException, JsonProcessingException {
+        if (value.arguments.length == 1 && value.rules == null) {
+            jgen.writeString(value.arguments[0]);
+        }
+        else {
+            jgen.writeStartObject();
+            jgen.writeArrayFieldStart("rules");
+            for (ArgumentRule rule : value.rules) {
+                // delegate to Rule, so member can stay private:
+                rule.serialize(jgen);
+            }
+            jgen.writeEndArray();
+            if (value.arguments.length == 1) {
+                jgen.writeStringField("value", value.arguments[0]);
+            }
+            else {
+                jgen.writeArrayFieldStart("value");
+                for (String arg : value.arguments) {
+                    jgen.writeString(arg);
+                }                
+                jgen.writeEndArray();
+            }
+            jgen.writeEndObject();
+        }
+    }
+}

--- a/launcher/src/main/java/com/skcraft/launcher/model/minecraft/Arguments.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/minecraft/Arguments.java
@@ -1,0 +1,57 @@
+/*
+ * part of the new version manifest handling, see https://github.com/SKCraft/Launcher/issues/235
+ * based on the pull request https://github.com/SKCraft/Launcher/pull/265 from EazFTW
+ */
+package com.skcraft.launcher.model.minecraft;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.skcraft.launcher.util.Environment;
+
+import lombok.Data;
+
+@Data
+public class Arguments {
+
+    private Argument[] game;
+    private Argument[] jvm;
+
+    @JsonIgnore
+    public String[] getGameArguments() {
+        ArrayList<String> args = new ArrayList<String>();
+        
+        for (Argument arg : game) {
+            arg.addArgs(args, null);
+        }
+        
+        return args.toArray(new String[args.size()]);
+    }
+
+    @JsonIgnore
+    public String[] getJVMArgs() {
+        if (jvm != null) {
+            ArrayList<String> args = new ArrayList<String>(); 
+            
+            for (Argument arg : jvm) {
+                arg.addArgs(args, null);
+            }
+            return args.toArray(new String[args.size()]);
+        }
+        return null;
+    }
+
+    @JsonIgnore
+    public List<String> getOSDependentArgs(Environment environment) {
+        if (jvm != null) {
+            ArrayList<String> args = new ArrayList<String>(); 
+            
+            for (Argument arg : jvm) {
+                arg.addArgs(args, environment);
+            }
+            return args;
+        }
+        return null;
+    }
+}

--- a/launcher/src/main/java/com/skcraft/launcher/model/minecraft/DownloadData.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/minecraft/DownloadData.java
@@ -1,0 +1,27 @@
+/*
+ * part of the new version manifest handling, see https://github.com/SKCraft/Launcher/issues/235
+ * based on the pull request https://github.com/SKCraft/Launcher/pull/265 from EazFTW
+ */
+package com.skcraft.launcher.model.minecraft;
+
+import java.net.URL;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.skcraft.launcher.util.HttpRequest;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DownloadData {
+
+    private String url;
+
+    // note that naming this wrapper 'getURL' will irritate the JSON parser, resulting in url = null
+    @JsonIgnore
+    public URL getDownloadURL() {
+        return (url == null || url.isEmpty()) ? null : HttpRequest.url(url);
+    }
+
+}

--- a/launcher/src/main/java/com/skcraft/launcher/model/minecraft/ManifestJSON.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/minecraft/ManifestJSON.java
@@ -1,0 +1,40 @@
+/*
+ * part of the new version manifest handling, see https://github.com/SKCraft/Launcher/issues/235
+ * based on the pull request https://github.com/SKCraft/Launcher/pull/265 from EazFTW
+ */
+package com.skcraft.launcher.model.minecraft;
+
+import lombok.Data;
+
+import java.net.URL;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.skcraft.launcher.util.HttpRequest;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ManifestJSON {
+
+    private List<MinecraftVersion> versions;
+
+    public static URL getVersionURL(URL manifestURL, String version) {
+        try {
+            ManifestJSON json = HttpRequest
+                    .get(manifestURL)
+                    .execute()
+                    .expectResponseCode(200)
+                    .returnContent()
+                    .asJson(ManifestJSON.class);
+            for(MinecraftVersion v : json.versions) {
+                if(v.getId().equalsIgnoreCase(version)) {
+                    return HttpRequest.url(v.getUrl());
+                }
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+    
+}

--- a/launcher/src/main/java/com/skcraft/launcher/model/minecraft/MinecraftVersion.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/minecraft/MinecraftVersion.java
@@ -1,0 +1,18 @@
+/*
+ * part of the new version manifest handling, see https://github.com/SKCraft/Launcher/issues/235
+ * based on the pull request https://github.com/SKCraft/Launcher/pull/265 from EazFTW
+ */
+package com.skcraft.launcher.model.minecraft;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MinecraftVersion {
+
+    private String id;
+    private String url;
+
+}

--- a/launcher/src/main/java/com/skcraft/launcher/model/minecraft/VersionAssetIndex.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/minecraft/VersionAssetIndex.java
@@ -1,0 +1,26 @@
+/*
+ * part of the new version manifest handling, see https://github.com/SKCraft/Launcher/issues/235
+ * based on the pull request https://github.com/SKCraft/Launcher/pull/265 from EazFTW
+ */
+package com.skcraft.launcher.model.minecraft;
+
+import java.net.URL;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.skcraft.launcher.util.HttpRequest;
+
+import lombok.Data;
+
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class VersionAssetIndex {
+
+    private String url;
+    
+    // note that naming this wrapper 'getURL' will irritate the JSON parser, resulting in url = null
+    @JsonIgnore
+    public URL getAssetIndexURL() {
+        return (url == null || url.isEmpty()) ? null : HttpRequest.url(url);
+    }
+}

--- a/launcher/src/main/java/com/skcraft/launcher/model/minecraft/VersionDownloads.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/minecraft/VersionDownloads.java
@@ -1,0 +1,15 @@
+/*
+ * part of the new version manifest handling, see https://github.com/SKCraft/Launcher/issues/235
+ * based on the pull request https://github.com/SKCraft/Launcher/pull/265 from EazFTW
+ */
+package com.skcraft.launcher.model.minecraft;
+
+import lombok.Data;
+
+@Data
+public class VersionDownloads {
+
+	private DownloadData client;
+    private DownloadData server;
+
+}

--- a/launcher/src/main/java/com/skcraft/launcher/model/minecraft/VersionManifest.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/minecraft/VersionManifest.java
@@ -8,10 +8,16 @@ package com.skcraft.launcher.model.minecraft;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.skcraft.launcher.util.Environment;
+import com.skcraft.launcher.util.HttpRequest;
+
 import lombok.Data;
 
+import java.io.IOException;
+import java.net.URL;
 import java.util.Date;
 import java.util.LinkedHashSet;
+import java.util.List;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -23,14 +29,95 @@ public class VersionManifest {
     private String assets;
     private String type;
     private String processArguments;
+    // minecraftArguments exists only up to 1.12.2
     private String minecraftArguments;
+    // beginning with snapshot 17w43a, it starts getting complicated
+    private Arguments arguments;
     private String mainClass;
     private int minimumLauncherVersion;
-    private LinkedHashSet<Library> libraries;
+    // if libraries is a LinkedHashMap, then the Deserializer will "forget" some libraries (they are read from the JSON and added to the internal collection,
+    // but are not there when it is assigned to the VersionManifest instance - my best guess is that those are hash collisions)
+    // also, the natives member will be empty on all.
+    // changing to Library[] fixes both issues, but requires helper functions addLibraries and containsLibarary
+    private Library[] libraries;
+    private VersionDownloads downloads;
+    private VersionAssetIndex assetIndex;
+
+    @JsonIgnore
+    private URL fetchURL;
 
     @JsonIgnore
     public String getAssetsIndex() {
         return getAssets() != null ? getAssets() : "legacy";
+    }
+
+    @JsonIgnore
+    public void addLibraries(LinkedHashSet<Library> libs) {
+        Library[] newLibs = new Library[libraries.length + libs.size()];
+        int       idx = 0;
+
+        for (Library lib : libraries) {
+            newLibs[idx++] = lib;
+        }
+        for (Library lib : libs) {
+            newLibs[idx++] = lib;
+        }
+        libraries = newLibs;
+    }
+
+    public boolean containsLibrary(Library library) {
+        for (Library lib : libraries) {
+            if (lib.equals(library))
+                return true;
+        }
+        return false;
+    }
+
+    @JsonIgnore
+    public URL getClientDownloadURL() {
+        return downloads.getClient().getDownloadURL();
+    }
+
+    @JsonIgnore
+    public static VersionManifest getInstance(URL manifestURL, String version) {
+        URL url = ManifestJSON.getVersionURL(manifestURL, version);
+        if (url != null) {
+            try {
+                VersionManifest instance = HttpRequest
+                        .get(url)
+                        .execute()
+                        .expectResponseCode(200)
+                        .returnContent()
+                        .asJson(VersionManifest.class);
+                instance.fetchURL = url;
+                return instance;
+            } catch (IOException e) {
+                e.printStackTrace();
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+        return null;
+
+    }
+
+    @JsonIgnore
+    public String[] getVersionIndependentMinecraftArguments() {
+        if (minecraftArguments != null) // up to 1.12.2
+            return minecraftArguments.split(" +");
+        if (arguments != null) // snapshot 17w43a and later
+            return arguments.getGameArguments();
+        return null;
+    }
+
+    @JsonIgnore
+    public String[] getJVMArgs() {
+        return (arguments != null) ? arguments.getJVMArgs() : null;
+    }
+
+    @JsonIgnore
+    public List<String> getOSDependentJVMArgs(Environment environment) {
+        return (arguments != null) ? arguments.getOSDependentArgs(environment) : null;
     }
 
 }

--- a/launcher/src/main/java/com/skcraft/launcher/util/ListUtil.java
+++ b/launcher/src/main/java/com/skcraft/launcher/util/ListUtil.java
@@ -1,0 +1,20 @@
+package com.skcraft.launcher.util;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+// utility class for Lists
+public final class ListUtil {
+
+    public static boolean contains(List<String> list, String regex) {
+        Pattern p = Pattern.compile(regex);
+        
+        for (String s:list) {
+            if (p.matcher(s).matches()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+}

--- a/launcher/src/main/resources/com/skcraft/launcher/launcher.properties
+++ b/launcher/src/main/resources/com/skcraft/launcher/launcher.properties
@@ -8,10 +8,8 @@ version=${project.version}
 agentName=Minecraft
 offlinePlayerName=Player
 
-versionManifestUrl=https://s3.amazonaws.com/Minecraft.Download/versions/%1$s/%1$s.json
+versionManifestUrl=https://launchermeta.mojang.com/mc/game/version_manifest.json
 librariesSource=https://libraries.minecraft.net/
-jarUrl=https://s3.amazonaws.com/Minecraft.Download/versions/%1$s/%1$s.jar
-assetsIndexUrl=https://s3.amazonaws.com/Minecraft.Download/indexes/%s.json
 assetsSource=http://resources.download.minecraft.net/
 yggdrasilAuthUrl=https://authserver.mojang.com/authenticate
 resetPasswordUrl=https://minecraft.net/resetpassword


### PR DESCRIPTION
This is a fix for https://github.com/SKCraft/Launcher/issues/235
- read new version_manifest.json and take URL for VersionManifest from there
- handle format changes in the version manifests after 1.12.2
- bugfix in VersionManifest: if libraries is a LinkedHashSet, some data got lost
  during parsing - some libraries were missing completely, others lost their natives
  which is also the reason why the native lwjgl libraries were missing