### PR TITLE
Make ClientFileCollector parallel

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ subprojects {
     group = 'com.skcraft'
     version = '4.3-SNAPSHOT'
 
-    sourceCompatibility = 1.6
-    targetCompatibility = 1.6
+    sourceCompatibility = 1.8
+    targetCompatibility = 1.8
 
     repositories {
         mavenCentral()

--- a/launcher-builder/src/main/java/com/skcraft/launcher/builder/DirectoryWalker.java
+++ b/launcher-builder/src/main/java/com/skcraft/launcher/builder/DirectoryWalker.java
@@ -7,6 +7,7 @@
 package com.skcraft.launcher.builder;
 
 import lombok.NonNull;
+import lombok.extern.java.Log;
 
 import java.io.File;
 import java.io.IOException;
@@ -16,6 +17,7 @@ import java.io.IOException;
  * path (which may be modified by dropping certain directory entries),
  * and call {@link #onFile(java.io.File, String)} with each file.
  */
+@Log
 public abstract class DirectoryWalker {
 
     public enum DirectoryBehavior {
@@ -40,7 +42,11 @@ public abstract class DirectoryWalker {
      * @throws IOException thrown on I/O error
      */
     public final void walk(@NonNull File dir) throws IOException {
-        walk(dir, "");
+        long start = System.currentTimeMillis();
+    	walk(dir, "");
+        long stop = System.currentTimeMillis();
+        log.info("Directory walk complete in " + (stop - start) + "ms.");
+        this.onWalkComplete();
     }
 
     /**
@@ -80,7 +86,7 @@ public abstract class DirectoryWalker {
      * Return the behavior for the given directory name.
      *
      * @param name the directory name
-     * @return the behavor
+     * @return the behavior
      */
     protected DirectoryBehavior getBehavior(String name) {
         return DirectoryBehavior.CONTINUE;
@@ -96,4 +102,8 @@ public abstract class DirectoryWalker {
     protected abstract void onFile(File file, String relPath) throws IOException;
 
 
+    /**
+     * Called after the walk is completed.
+     */
+    protected void onWalkComplete() {};
 }

--- a/launcher/src/main/java/com/skcraft/launcher/model/modpack/Manifest.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/modpack/Manifest.java
@@ -22,6 +22,7 @@ import lombok.Setter;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 @Data
@@ -39,7 +40,7 @@ public class Manifest extends BaseManifest {
     private LaunchModifier launchModifier;
     private List<Feature> features = new ArrayList<Feature>();
     @JsonManagedReference("manifest")
-    private List<ManifestEntry> tasks = new ArrayList<ManifestEntry>();
+    private List<ManifestEntry> tasks = Collections.synchronizedList(new ArrayList<ManifestEntry>());
     @Getter @Setter @JsonIgnore
     private Installer installer;
     private VersionManifest versionManifest;


### PR DESCRIPTION
While working on a large modpack I got annoyed at waiting for the launcher to start launching.

On my 6 physical core, NVME SSD computer, this brings the processing time down from \~20 seconds to \~3.5 seconds . This is about a 5.7~6x improvement.

