### PR TITLE
Add User-Agent to news page HTTP requests

### DIFF
--- a/launcher/src/main/java/com/skcraft/launcher/swing/WebpagePanel.java
+++ b/launcher/src/main/java/com/skcraft/launcher/swing/WebpagePanel.java
@@ -250,6 +250,7 @@ public final class WebpagePanel extends JPanel {
                 conn = (HttpURLConnection) url.openConnection();
                 conn.setRequestMethod("GET");
                 conn.setUseCaches(false);
+                conn.setRequestProperty("User-Agent", "Mozilla/5.0 (Java) SKMCLauncher");
                 conn.setDoInput(true);
                 conn.setDoOutput(false);
                 conn.setReadTimeout(5000);


### PR DESCRIPTION
Currently, the news fetching request uses an HttpURLConnection that doesn't specify a user agent. Cloudflare, and possibly some other MITM proxies, consider the default Java 1.8 user agent to be fishy/unsafe and reject it with a 403 on request. This means that those fronting their SKC Launcher with Cloudflare won't be able to load the news on Java 1.8 instances (doesn't seem to happen with later versions).

This PR simply adds a parameter to the request to set a user-agent similar to the HttpURLConnection for fetching the packages. As a result, the news page successfully loads.