### PR TITLE
Style Account Select Dialog

### DIFF
--- a/launcher/src/main/java/com/skcraft/launcher/dialog/AccountSelectDialog.java
+++ b/launcher/src/main/java/com/skcraft/launcher/dialog/AccountSelectDialog.java
@@ -44,7 +44,7 @@ public class AccountSelectDialog extends JDialog {
 		setTitle(SharedLocale.tr("accounts.title"));
 		initComponents();
 		setDefaultCloseOperation(DISPOSE_ON_CLOSE);
-		setMinimumSize(new Dimension(350, 170));
+		setMinimumSize(new Dimension(350, 250));
 		setResizable(false);
 		pack();
 		setLocationRelativeTo(owner);
@@ -59,37 +59,38 @@ public class AccountSelectDialog extends JDialog {
 		accountList.setCellRenderer(new AccountRenderer());
 
 		JScrollPane accountPane = new JScrollPane(accountList);
-		accountPane.setPreferredSize(new Dimension(250, 100));
+		accountPane.setPreferredSize(new Dimension(280, 150));
 		accountPane.setAlignmentX(CENTER_ALIGNMENT);
 
 		loginButton.setFont(loginButton.getFont().deriveFont(Font.BOLD));
 		loginButton.setMargin(new Insets(0, 10, 0, 10));
 
+		//Start Buttons
 		buttonsPanel.setBorder(BorderFactory.createEmptyBorder(26, 13, 13, 13));
 		if (launcher.getConfig().isOfflineEnabled()) {
 			buttonsPanel.addElement(offlineButton);
 		}
 		buttonsPanel.addGlue();
-		buttonsPanel.addElement(loginButton);
 		buttonsPanel.addElement(cancelButton);
+		buttonsPanel.addElement(loginButton);
 
-		LinedBoxPanel loginButtonsRow = new LinedBoxPanel(true);
-		loginButtonsRow.add(addMojangButton);
-		loginButtonsRow.add(addMicrosoftButton);
-		loginButtonsRow.addGlue();
-		loginButtonsRow.add(removeSelected);
-		loginButtonsRow.setAlignmentX(CENTER_ALIGNMENT);
-		loginButtonsRow.setBorder(null);
+		//Login Buttons
+		LinedBoxPanel loginButtonsRow = new LinedBoxPanel(false);
+		addMojangButton.setAlignmentX(CENTER_ALIGNMENT);
+		addMicrosoftButton.setAlignmentX(CENTER_ALIGNMENT);
+		removeSelected.setAlignmentX(CENTER_ALIGNMENT);
+		loginButtonsRow.addElement(addMojangButton);
+		loginButtonsRow.addElement(addMicrosoftButton);
+		loginButtonsRow.addElement(removeSelected);
+		loginButtonsRow.setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 0));
 
-		JPanel listPane = new JPanel();
-		listPane.setLayout(new BoxLayout(listPane, BoxLayout.Y_AXIS));
-		listPane.add(accountPane);
-		listPane.add(Box.createVerticalStrut(5));
-		listPane.add(loginButtonsRow);
-		listPane.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
-		listPane.setAlignmentX(CENTER_ALIGNMENT);
+		JPanel listAndLoginContainer = new JPanel();
+		listAndLoginContainer.add(accountPane, BorderLayout.WEST);
+		listAndLoginContainer.add(loginButtonsRow, BorderLayout.EAST);
+		listAndLoginContainer.add(Box.createVerticalStrut(5));
+		listAndLoginContainer.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
 
-		add(listPane, BorderLayout.CENTER);
+		add(listAndLoginContainer, BorderLayout.CENTER);
 		add(buttonsPanel, BorderLayout.SOUTH);
 
 		loginButton.addActionListener(ev -> attemptExistingLogin(accountList.getSelectedValue()));
@@ -215,7 +216,7 @@ public class AccountSelectDialog extends JDialog {
 
 	private static class AccountRenderer extends JLabel implements ListCellRenderer<SavedSession> {
 		public AccountRenderer() {
-			setHorizontalAlignment(CENTER);
+			setHorizontalAlignment(LEFT);
 		}
 
 		@Override


### PR DESCRIPTION
Design is really a personal thing so feel free to deny or adapt the PR to your likings.

But I thought it's wasted space to have such a wide list for relatively short MC Names.

- left aligned account list entries
- right aligned login buttons
- swapped order of cancel and start button - from a usability perspective, thats the way to go. Also keeps at consistent with the Settings/Start Button in the main windows
- added spaces here and there

Not sure about the Pixel values. I am using the Launcher on an UHD display.

Outcome:
![image](https://user-images.githubusercontent.com/4679374/108566468-c65e5100-7306-11eb-9b17-104869fa2add.png)


