### PR TITLE
Allow zip files as libraries.

### DIFF
--- a/launcher-builder/src/main/java/com/skcraft/launcher/builder/PackageBuilder.java
+++ b/launcher-builder/src/main/java/com/skcraft/launcher/builder/PackageBuilder.java
@@ -265,7 +265,7 @@ public class PackageBuilder {
         try {
             log.info("Downloading library " + library.getName() + " from " + url + "...");
             HttpRequest.get(url).execute().expectResponseCode(200)
-                    .expectContentType("application/java-archive", "application/octet-stream")
+                    .expectContentType("application/java-archive", "application/octet-stream", "application/zip")
                     .saveContent(tempFile);
         } catch (IOException e) {
             log.info("Could not get file from " + url + ": " + e.getMessage());


### PR DESCRIPTION
While trying to create a modpack with Forge for v1.19, the build fails as Forge provides the _mcp_config_ library as a zip file. This causes the builder to fail to download as it doesn't allow zip files as a content type.

`[info] Downloading library de.oceanlabs.mcp:mcp_config:1.19.2-20220805.130853@zip from https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_config/1.19.2-20220805.130853/mcp_config-1.19.2-20220805.130853.zip...`
`[info] Could not get file from https://maven.minecraftforge.net/de/oceanlabs/mcp/mcp_config/1.19.2-20220805.130853/mcp_config-1.19.2-20220805.130853.zip: Did not get expected content type 'application/java-archive | application/octet-stream', instead got 'application/zip'.`

![temp](https://user-images.githubusercontent.com/861156/184951214-297b65ec-db93-4e34-8732-1dff4a6644d0.png)