### PR TITLE
Fix Gradle warnings about "Execution optimizations" and dependencies

### DIFF
--- a/creator-tools/build.gradle
+++ b/creator-tools/build.gradle
@@ -24,6 +24,34 @@ processResources {
     }
 }
 
+compileJava {
+    dependsOn(':launcher-builder:jar')
+}
+
+startScripts {
+    dependsOn(shadowJar)
+}
+
+distTar {
+    dependsOn(shadowJar)
+}
+
+distZip {
+    dependsOn(shadowJar)
+}
+
+startShadowScripts {
+    dependsOn(jar)
+}
+
+shadowDistTar {
+    dependsOn(jar)
+}
+
+shadowDistZip {
+    dependsOn(jar)
+}
+
 shadowJar {
     archiveClassifier.set("")
 }

--- a/launcher-bootstrap/build.gradle
+++ b/launcher-bootstrap/build.gradle
@@ -21,6 +21,30 @@ processResources {
     }
 }
 
+startScripts {
+    dependsOn(shadowJar)
+}
+
+distTar {
+    dependsOn(shadowJar)
+}
+
+distZip {
+    dependsOn(shadowJar)
+}
+
+startShadowScripts {
+    dependsOn(jar)
+}
+
+shadowDistTar {
+    dependsOn(jar)
+}
+
+shadowDistZip {
+    dependsOn(jar)
+}
+
 shadowJar {
     archiveClassifier.set("")
 }

--- a/launcher-builder/build.gradle
+++ b/launcher-builder/build.gradle
@@ -14,6 +14,33 @@ dependencies {
     implementation 'org.apache.commons:commons-compress:1.21'
 }
 
+startScripts {
+    dependsOn(':launcher:shadowJar')
+    dependsOn(shadowJar)
+}
+
+distTar {
+    dependsOn(':launcher:shadowJar')
+    dependsOn(shadowJar)
+}
+
+distZip {
+    dependsOn(':launcher:shadowJar')
+    dependsOn(shadowJar)
+}
+
+startShadowScripts {
+    dependsOn(jar)
+}
+
+shadowDistTar {
+    dependsOn(jar)
+}
+
+shadowDistZip {
+    dependsOn(jar)
+}
+
 shadowJar {
     archiveClassifier.set("")
 }

--- a/launcher-fancy/build.gradle
+++ b/launcher-fancy/build.gradle
@@ -20,7 +20,39 @@ dependencies {
     implementation 'io.github.cottonmc.insubstantial:substance:7.3.1-SNAPSHOT'
 }
 
+compileJava {
+    dependsOn(':launcher:jar')
+}
+
+startScripts {
+    dependsOn(':launcher:jar')
+    dependsOn(shadowJar)
+}
+
+distTar {
+    dependsOn(':launcher:jar')
+    dependsOn(shadowJar)
+}
+
+distZip {
+    dependsOn(':launcher:jar')
+    dependsOn(shadowJar)
+}
+
+startShadowScripts {
+    dependsOn(jar)
+}
+
+shadowDistTar {
+    dependsOn(jar)
+}
+
+shadowDistZip {
+    dependsOn(jar)
+}
+
 shadowJar {
+    dependsOn(':launcher:jar')
     archiveClassifier.set("")
 }
 

--- a/launcher/build.gradle
+++ b/launcher/build.gradle
@@ -31,6 +31,30 @@ processResources {
     }
 }
 
+startScripts {
+    dependsOn(shadowJar)
+}
+
+distTar {
+    dependsOn(shadowJar)
+}
+
+distZip {
+    dependsOn(shadowJar)
+}
+
+startShadowScripts {
+    dependsOn(jar)
+}
+
+shadowDistTar {
+    dependsOn(jar)
+}
+
+shadowDistZip {
+    dependsOn(jar)
+}
+
 shadowJar {
     archiveClassifier.set("")
 }


### PR DESCRIPTION
This fixes the "execution optimization" warnings and the "launcher-builder" project failing to build correctly. This appears to fix #484.