### PR TITLE
Prevent Forge's Log4j configuration from being overridden by vanilla's

### DIFF
--- a/launcher-builder/src/main/java/com/skcraft/launcher/builder/loaders/ModernForgeLoaderProcessor.java
+++ b/launcher-builder/src/main/java/com/skcraft/launcher/builder/loaders/ModernForgeLoaderProcessor.java
@@ -73,6 +73,12 @@ public class ModernForgeLoaderProcessor implements ILoaderProcessor {
 					}
 				}
 
+				// Copy logging config
+				SidedData<VersionManifest.LoggingConfig> loggingConfig = info.getLogging();
+				if (loggingConfig != null) {
+					version.setLogging(loggingConfig);
+				}
+
 				// Copy main class
 				String mainClass = info.getMainClass();
 				if (mainClass != null) {

--- a/launcher/src/main/java/com/skcraft/launcher/launch/Runner.java
+++ b/launcher/src/main/java/com/skcraft/launcher/launch/Runner.java
@@ -307,7 +307,7 @@ public class Runner implements Callable<Process>, ProgressObservable {
             }
         }
 
-        if (versionManifest.getLogging() != null) {
+        if (versionManifest.getLogging() != null && versionManifest.getLogging().getClient() != null) {
             log.info("Logging config present, log4j2 bug likely mitigated");
 
             VersionManifest.LoggingConfig config = versionManifest.getLogging().getClient();

--- a/launcher/src/main/java/com/skcraft/launcher/launch/Runner.java
+++ b/launcher/src/main/java/com/skcraft/launcher/launch/Runner.java
@@ -140,7 +140,6 @@ public class Runner implements Callable<Process>, ProgressObservable {
         }
 
         progress = new DefaultProgress(0.9, SharedLocale.tr("runner.collectingArgs"));
-        builder.classPath(getJarPath());
         builder.setMainClass(versionManifest.getMainClass());
 
         addWindowArgs();
@@ -232,6 +231,9 @@ public class Runner implements Callable<Process>, ProgressObservable {
                         tr("runner.missingLibrary", instance.getTitle(), library.getName()));
             }
         }
+
+        // The official launcher puts the vanilla jar at the end of the classpath, we'll do the same
+        builder.classPath(getJarPath());
     }
 
     /**

--- a/launcher/src/main/java/com/skcraft/launcher/model/loader/VersionInfo.java
+++ b/launcher/src/main/java/com/skcraft/launcher/model/loader/VersionInfo.java
@@ -12,6 +12,7 @@ import com.google.common.base.Splitter;
 import com.skcraft.launcher.model.minecraft.GameArgument;
 import com.skcraft.launcher.model.minecraft.Library;
 import com.skcraft.launcher.model.minecraft.MinecraftArguments;
+import com.skcraft.launcher.model.minecraft.VersionManifest;
 import lombok.Data;
 
 import java.util.List;
@@ -23,6 +24,7 @@ public class VersionInfo {
     private MinecraftArguments arguments;
     private String mainClass;
     private List<Library> libraries;
+    private SidedData<VersionManifest.LoggingConfig> logging;
 
     @JsonIgnore private transient boolean overridingArguments;
 

--- a/launcher/src/main/java/com/skcraft/launcher/update/BaseUpdater.java
+++ b/launcher/src/main/java/com/skcraft/launcher/update/BaseUpdater.java
@@ -282,7 +282,7 @@ public abstract class BaseUpdater {
         }
 
         // Use our custom logging config depending on what the manifest specifies
-        if (versionManifest.getLogging() != null) {
+        if (versionManifest.getLogging() != null && versionManifest.getLogging().getClient() != null) {
             VersionManifest.LoggingConfig config = versionManifest.getLogging().getClient();
 
             VersionManifest.Artifact file = config.getFile();


### PR DESCRIPTION
This fixes a few minor inconsistencies (compared to vanilla launcher behavior) in order to ensure that Forge's Log4j configuration actually gets loaded. Without this, the vanilla Log4j config is always used, which means that a `debug.log` is never generated.