### PR TITLE
Add null check to xdgFolderName. Fixes Linux fail to launch.

### DIFF
--- a/launcher-bootstrap/src/main/java/com/skcraft/launcher/Bootstrap.java
+++ b/launcher-bootstrap/src/main/java/com/skcraft/launcher/Bootstrap.java
@@ -199,7 +199,7 @@ public class Bootstrap {
         File dotFolder = new File(System.getProperty("user.home"), getProperties().getProperty("homeFolder"));
         String xdgFolderName = getProperties().getProperty("homeFolderLinux");
 
-        if (osName.contains("linux") && !dotFolder.exists() && !xdgFolderName.isEmpty()) {
+        if (osName.contains("linux") && !dotFolder.exists() && xdgFolderName != null && !xdgFolderName.isEmpty()) {
             String xdgDataHome = System.getenv("XDG_DATA_HOME");
             if (xdgDataHome.isEmpty()) {
                 xdgDataHome = System.getProperty("user.home") + "/.local/share";


### PR DESCRIPTION
Ever since the "[Linux XDG folder support](https://github.com/SKCraft/Launcher/pull/518)" fresh Linux installs fail to start the Launcher with the error:

```
Exception in thread "main" java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "xdgFolderName" is null
	at com.skcraft.launcher.Bootstrap.getUserLauncherDir(Bootstrap.java:202)
	at com.skcraft.launcher.Bootstrap.<init>(Bootstrap.java:59)
	at com.skcraft.launcher.Bootstrap.main(Bootstrap.java:45)
```

This very small fix adds a null check, and the Launcher works on fresh Linux installs again.