### PR TITLE
Fix Zip Slip path traversal vulnerability in ZipExtract

### DIFF
--- a/launcher/src/main/java/com/skcraft/launcher/install/ZipExtract.java
+++ b/launcher/src/main/java/com/skcraft/launcher/install/ZipExtract.java
@@ -46,6 +46,10 @@ public class ZipExtract implements Runnable {
             while ((entry = zis.getNextEntry()) != null) {
                 if (matches(entry)) {
                     File file = new File(getDestination(), entry.getName());
+                    if (!file.getCanonicalPath().startsWith(getDestination().getCanonicalPath() + File.separator)
+                            && !file.getCanonicalPath().equals(getDestination().getCanonicalPath())) {
+                        throw new IOException("Zip entry outside target directory: " + entry.getName());
+                    }
                     if (entry.isDirectory()) {
                         file.mkdirs();
                     } else {


### PR DESCRIPTION
## Summary

ZipExtract does not validate that zip entry paths resolve within the destination directory. A crafted zip containing entries like `../../etc/passwd` can write files to arbitrary locations on disk (Zip Slip / CVE-2018-1263 class vulnerability).

Added a canonical path check before extraction to reject any entry that resolves outside the target directory.

## Changes

- `launcher/src/main/java/com/skcraft/launcher/install/ZipExtract.java`: validate extracted file path stays within destination