### PR TITLE
Remove HTTP 202 (Accepted) from redirect handling

### DIFF
--- a/launcher-bootstrap/src/main/java/com/skcraft/launcher/bootstrap/HttpRequest.java
+++ b/launcher-bootstrap/src/main/java/com/skcraft/launcher/bootstrap/HttpRequest.java
@@ -153,7 +153,6 @@ public class HttpRequest implements Closeable, ProgressObservable {
                 body = null;
             case HttpURLConnection.HTTP_MOVED_PERM:
             case HttpURLConnection.HTTP_MOVED_TEMP:
-            case HttpURLConnection.HTTP_ACCEPTED:
             case 307:
             case 308:
                 String location = conn.getHeaderField("Location");


### PR DESCRIPTION
## Summary

The bootstrap `HttpRequest` redirect switch includes `HTTP_ACCEPTED` (202), but 202 is not a redirect status code. It means the server accepted the request for processing. When a server returns 202, the code tries to follow a `Location` header that likely doesn't exist, causing a NullPointerException or malformed URL error.

## Changes

- `launcher-bootstrap/src/main/java/com/skcraft/launcher/bootstrap/HttpRequest.java`: remove `HTTP_ACCEPTED` from the redirect switch case