### PR TITLE
Fix launcher-fancy build by using Maven Central Substance dependency

### DIFF
--- a/launcher-fancy/build.gradle
+++ b/launcher-fancy/build.gradle
@@ -8,16 +8,9 @@ application {
     mainClassName = "com.skcraft.launcher.FancyLauncher"
 }
 
-repositories {
-    maven {
-        name = 'bbkr.space maven'
-        url = 'https://server.bbkr.space/artifactory/libs-snapshot'
-    }
-}
-
 dependencies {
     implementation project(path: ':launcher')
-    implementation 'io.github.cottonmc.insubstantial:substance:7.3.1-SNAPSHOT'
+    implementation 'com.github.insubstantial:substance:7.3'
 }
 
 shadowJar {


### PR DESCRIPTION
The CottonMC Artifactory at server.bbkr.space is unreachable, breaking resolution of io.github.cottonmc.insubstantial:substance:7.3.1-SNAPSHOT. Switch to com.github.insubstantial:substance:7.3 from Maven Central, which is already configured in the root build.

Fixes #546