### PR TITLE
Migrate launcher-fancy from Insubstantial Substance to Radiance

### DIFF
--- a/launcher-fancy/build.gradle
+++ b/launcher-fancy/build.gradle
@@ -16,6 +16,12 @@ java {
     }
 }
 
+// Target the Java 17 floor so a single artifact runs on both Java 17 and 21.
+// Without this, the JDK 21 toolchain emits Java 21 bytecode that won't load on 17.
+tasks.withType(JavaCompile).configureEach {
+    options.release.set(17)
+}
+
 // The Lombok bundled with the root freefair plugin (1.18.20) can't access JDK
 // compiler internals on Java 16+. Pin a version that supports the JDK 21 toolchain.
 lombok {

--- a/launcher-fancy/build.gradle
+++ b/launcher-fancy/build.gradle
@@ -8,16 +8,23 @@ application {
     mainClassName = "com.skcraft.launcher.FancyLauncher"
 }
 
-repositories {
-    maven {
-        name = 'bbkr.space maven'
-        url = 'https://server.bbkr.space/artifactory/libs-snapshot'
+// Radiance ships Java 9 bytecode, so this module needs a JDK 9+ toolchain,
+// overriding the Java 8 toolchain that the root build applies to every module.
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
     }
+}
+
+// The Lombok bundled with the root freefair plugin (1.18.20) can't access JDK
+// compiler internals on Java 16+. Pin a version that supports the JDK 21 toolchain.
+lombok {
+    version = "1.18.34"
 }
 
 dependencies {
     implementation project(path: ':launcher')
-    implementation 'io.github.cottonmc.insubstantial:substance:7.3.1-SNAPSHOT'
+    implementation 'org.pushing-pixels:radiance-substance:4.5.0'
 }
 
 shadowJar {

--- a/launcher-fancy/src/main/java/com/skcraft/launcher/skin/LauncherSkin.java
+++ b/launcher-fancy/src/main/java/com/skcraft/launcher/skin/LauncherSkin.java
@@ -7,6 +7,11 @@
 package com.skcraft.launcher.skin;
 
 import org.pushingpixels.substance.api.*;
+import org.pushingpixels.substance.api.SubstanceSlices.ColorSchemeAssociationKind;
+import org.pushingpixels.substance.api.SubstanceSlices.DecorationAreaType;
+import org.pushingpixels.substance.api.colorscheme.ColorSchemeSingleColorQuery;
+import org.pushingpixels.substance.api.colorscheme.ColorSchemeTransform;
+import org.pushingpixels.substance.api.colorscheme.SubstanceColorScheme;
 import org.pushingpixels.substance.api.painter.border.ClassicBorderPainter;
 import org.pushingpixels.substance.api.painter.border.CompositeBorderPainter;
 import org.pushingpixels.substance.api.painter.border.DelegateBorderPainter;
@@ -18,7 +23,8 @@ import org.pushingpixels.substance.api.skin.GraphiteSkin;
 public class LauncherSkin extends GraphiteSkin {
 
     public LauncherSkin() {
-        ColorSchemes schemes = SubstanceSkin.getColorSchemes("com/skcraft/launcher/skin/graphite.colorschemes");
+        ColorSchemes schemes = SubstanceSkin.getColorSchemes(
+                LauncherSkin.class.getResourceAsStream("/com/skcraft/launcher/skin/graphite.colorschemes"));
 
         SubstanceColorScheme activeScheme = schemes.get("Graphite Active");
         SubstanceColorScheme selectedDisabledScheme = schemes.get("Graphite Selected Disabled");
@@ -36,10 +42,15 @@ public class LauncherSkin extends GraphiteSkin {
         SubstanceColorSchemeBundle scheme = new SubstanceColorSchemeBundle(activeScheme, enabledScheme, disabledScheme);
 
         // highlight fill scheme + custom alpha for rollover unselected state
-        scheme.registerHighlightColorScheme(highlightScheme, 0.6f, ComponentState.ROLLOVER_UNSELECTED);
-        scheme.registerHighlightColorScheme(highlightScheme, 0.8f, ComponentState.SELECTED);
-        scheme.registerHighlightColorScheme(highlightScheme, 1.0f, ComponentState.ROLLOVER_SELECTED);
-        scheme.registerHighlightColorScheme(highlightScheme, 0.75f, ComponentState.ARMED, ComponentState.ROLLOVER_ARMED);
+        // (Radiance split the combined scheme+alpha overload into two calls)
+        scheme.registerHighlightColorScheme(highlightScheme, ComponentState.ROLLOVER_UNSELECTED);
+        scheme.registerHighlightAlpha(0.6f, ComponentState.ROLLOVER_UNSELECTED);
+        scheme.registerHighlightColorScheme(highlightScheme, ComponentState.SELECTED);
+        scheme.registerHighlightAlpha(0.8f, ComponentState.SELECTED);
+        scheme.registerHighlightColorScheme(highlightScheme, ComponentState.ROLLOVER_SELECTED);
+        scheme.registerHighlightAlpha(1.0f, ComponentState.ROLLOVER_SELECTED);
+        scheme.registerHighlightColorScheme(highlightScheme, ComponentState.ARMED, ComponentState.ROLLOVER_ARMED);
+        scheme.registerHighlightAlpha(0.75f, ComponentState.ARMED, ComponentState.ROLLOVER_ARMED);
 
         // highlight border scheme
         scheme.registerColorScheme(highlightScheme, ColorSchemeAssociationKind.HIGHLIGHT_BORDER, ComponentState.getActiveStates());
@@ -47,13 +58,15 @@ public class LauncherSkin extends GraphiteSkin {
         scheme.registerColorScheme(separatorScheme, ColorSchemeAssociationKind.SEPARATOR);
 
         // text highlight scheme
-        scheme.registerColorScheme(textHighlightScheme, ColorSchemeAssociationKind.TEXT_HIGHLIGHT, ComponentState.SELECTED, ComponentState.ROLLOVER_SELECTED);
+        scheme.registerColorScheme(textHighlightScheme, ColorSchemeAssociationKind.HIGHLIGHT_TEXT, ComponentState.SELECTED, ComponentState.ROLLOVER_SELECTED);
         scheme.registerColorScheme(highlightScheme, ComponentState.ARMED, ComponentState.ROLLOVER_ARMED);
         scheme.registerColorScheme(highlightMarkScheme, ColorSchemeAssociationKind.HIGHLIGHT_MARK, ComponentState.getActiveStates());
         scheme.registerColorScheme(highlightMarkScheme, ColorSchemeAssociationKind.MARK, ComponentState.ROLLOVER_SELECTED, ComponentState.ROLLOVER_UNSELECTED);
         scheme.registerColorScheme(borderScheme, ColorSchemeAssociationKind.MARK, ComponentState.SELECTED);
-        scheme.registerColorScheme(disabledScheme, 0.5f, ComponentState.DISABLED_UNSELECTED);
-        scheme.registerColorScheme(selectedDisabledScheme, 0.65f, ComponentState.DISABLED_SELECTED);
+        scheme.registerColorScheme(disabledScheme, ComponentState.DISABLED_UNSELECTED);
+        scheme.registerAlpha(0.5f, ComponentState.DISABLED_UNSELECTED);
+        scheme.registerColorScheme(selectedDisabledScheme, ComponentState.DISABLED_SELECTED);
+        scheme.registerAlpha(0.65f, ComponentState.DISABLED_SELECTED);
         scheme.registerColorScheme(highlightScheme, ComponentState.ROLLOVER_SELECTED);
         scheme.registerColorScheme(selectedScheme, ComponentState.SELECTED);
 
@@ -61,11 +74,10 @@ public class LauncherSkin extends GraphiteSkin {
 
         this.registerDecorationAreaSchemeBundle(scheme, backgroundScheme, DecorationAreaType.NONE);
 
-        this.setSelectedTabFadeStart(0.1);
-        this.setSelectedTabFadeEnd(0.3);
+        this.setTabFadeStart(0.1);
+        this.setTabFadeEnd(0.3);
 
         this.buttonShaper = new LauncherButtonShaper();
-        this.watermark = null;
         this.fillPainter = new FractionBasedFillPainter("Graphite",
                 new float[] { 0.0f, 0.5f, 1.0f },
                 new ColorSchemeSingleColorQuery[] {
@@ -87,8 +99,6 @@ public class LauncherSkin extends GraphiteSkin {
                 }));
 
         this.highlightBorderPainter = new ClassicBorderPainter();
-
-        this.watermarkScheme = schemes.get("Graphite Watermark");
     }
 
 }


### PR DESCRIPTION
## Problem

`launcher-fancy` depends on Insubstantial Substance, which is broken two ways:

1. Its Maven repo (`server.bbkr.space`) no longer exists — the domain is dead, so the module can't resolve its dependency.
2. The library throws a `NullPointerException` at startup on any JVM newer than Java 8 — the skin registers through JDK internals that the module system removed.

Switching to `com.github.insubstantial:substance:7.3` from Maven Central was ruled out: it compiles green but still throws the same startup NPE on Java 9+.

Resolves https://github.com/SKCraft/Launcher/issues/546

## Fix

Migrate to **`org.pushing-pixels:radiance-substance:4.5.0`** — the maintained successor by the same author (Kirill Grouchnikov), and the last release still using the `substance` package name (5.0+ renamed the artifact to `radiance-theming`).

**`launcher-fancy/build.gradle`**
- Remove the dead `server.bbkr.space` repository.
- Swap the dependency to `org.pushing-pixels:radiance-substance:4.5.0`.
- Give this module its own JDK 21 toolchain (overriding the root build's Java 8 toolchain), since Radiance ships Java 9 bytecode.
- Target the Java 17 bytecode floor (`options.release = 17`) so a single artifact runs on both Java 17 and 21.
- Pin Lombok 1.18.34 for this module — the root freefair plugin's bundled Lombok 1.18.20 can't access JDK compiler internals on Java 16+.

**`LauncherSkin.java`** — Radiance 4.5.0 API migration:
- Update imports for classes relocated to `…api.colorscheme` and nested under `…api.SubstanceSlices`.
- `getColorSchemes(String)` → `getColorSchemes(InputStream)` via `getResourceAsStream(...)`.
- Split the removed combined scheme+alpha register overloads into separate `register*Alpha` calls.
- Rename `TEXT_HIGHLIGHT` → `HIGHLIGHT_TEXT`.
- Replace `setSelectedTabFade*` with `setTabFade*`.
- Drop the removed `watermark` / `watermarkScheme` members.

`LauncherLookAndFeel.java` and `LauncherButtonShaper.java` are unchanged.

## ⚠️ Java version requirement (behaviour change)

`launcher-fancy` now **requires Java 17+ at both build and run time.** This is inherent to Radiance, whose jars are Java 9 bytecode. The other four modules are untouched and continue to build on the Java 8 toolchain.

| Java | Build | Run |
|------|-------|-----|
| **8** | ❌ Gradle refuses to resolve `radiance-substance:4.5.0` (declares Java 9 minimum) | ❌ `UnsupportedClassVersionError` |
| **17** | ✅ | ✅ verified on Temurin 17.0.19 |
| **21** | ✅ | ✅ verified |

(For context: the old Insubstantial dependency built on Java 8 but crashed at runtime on Java 9+, so a working Java 8 fancy launcher didn't exist under either library.)

## Verification

- `./gradlew :launcher-fancy:build` succeeds; recompiled classes are class-file major 61 (Java 17).
- The shadow jar starts cleanly on both **Temurin JDK 17.0.19** and **JDK 21** — instances enumerate, the Radiance skin applies, and there is no `NullPointerException` (`SwingHelper.setLookAndFeel` logs no fallback warning, confirming the skin applied rather than reverting to the system L&F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)